### PR TITLE
Rename settings variables to include CARETAKER prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Next, ensure that you have a working AWS cli client and configure it if not.
 
 Set the BACKUP_BUCKET variable in your settings.py file. This must be a globally unique name for the S3 bucket. You should also set the MEDIA_ROOT folder so that we know what to back up:
 
-    BACKUP_BUCKET = 'caretakertestbackup'
+    CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
+    CARETAKER_ADDITIONAL_BACKUP_PATHS = ['/home/user/path1', '/home/user/path2']
     MEDIA_ROOT = '/var/www/media'
 
 Generate and run Terraform configuration in your home directory:

--- a/django-caretaker/README.md
+++ b/django-caretaker/README.md
@@ -22,9 +22,9 @@ Next, ensure that you have a working AWS cli client and configure it if not.
 
 Set the BACKUP_BUCKET variable in your settings.py file. This must be a globally unique name for the S3 bucket. You should also set the MEDIA_ROOT folder so that we know what to back up:
 
-    BACKUP_BUCKET = 'caretakertestbackup'
+    CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
+    CARETAKER_ADDITIONAL_BACKUP_PATHS = ['/home/user/path1', '/home/user/path2']
     MEDIA_ROOT = '/var/www/media'
-    ADDITIONAL_BACKUP_PATHS = ['/home/user/path1', '/home/user/path2']
 
 Generate and run Terraform configuration in your home directory:
 

--- a/django-caretaker/caretaker/management/commands/create_backup.py
+++ b/django-caretaker/caretaker/management/commands/create_backup.py
@@ -62,10 +62,10 @@ class Command(BaseCommand):
             path_list.append(settings.MEDIA_ROOT)
 
         if hasattr(settings, 'ADDITIONAL_BACKUP_PATHS') \
-                and settings.ADDITIONAL_BACKUP_PATHS \
-                and settings.ADDITIONAL_BACKUP_PATHS not in path_list:
+                and settings.CARETAKER_ADDITIONAL_BACKUP_PATHS \
+                and settings.CARETAKER_ADDITIONAL_BACKUP_PATHS not in path_list:
 
-            path_list.extend(settings.ADDITIONAL_BACKUP_PATHS)
+            path_list.extend(settings.CARETAKER_ADDITIONAL_BACKUP_PATHS)
 
         path_list_final = [Path(path).expanduser().resolve(strict=True)
                            for path in path_list]

--- a/django-caretaker/caretaker/management/commands/get_terraform.py
+++ b/django-caretaker/caretaker/management/commands/get_terraform.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         with terraform_file.open('r') as in_file:
             # render the terraform file into a template
             t = Template(in_file.read())
-            c = Context({"bucket_name": settings.BACKUP_BUCKET})
+            c = Context({"bucket_name": settings.CARETAKER_BACKUP_BUCKET})
             rendered = t.render(c)
 
             # create the file structure

--- a/django-caretaker/caretaker/management/commands/install_cron.py
+++ b/django-caretaker/caretaker/management/commands/install_cron.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Installs Cron jobs
         """
-        self._install_cron(job_name=settings.BACKUP_BUCKET,
+        self._install_cron(job_name=settings.CARETAKER_BACKUP_BUCKET,
                            action=options.get('action'),
                            base_dir=settings.BASE_DIR)
 

--- a/django-caretaker/caretaker/management/commands/list_backups.py
+++ b/django-caretaker/caretaker/management/commands/list_backups.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
                           aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
 
         self._list_backups(s3_client=s3, remote_key=options.get('remote_key'),
-                           bucket_name=settings.BACKUP_BUCKET)
+                           bucket_name=settings.CARETAKER_BACKUP_BUCKET)
 
     @staticmethod
     def _list_backups(remote_key, s3_client, bucket_name):

--- a/django-caretaker/caretaker/management/commands/pull_backup.py
+++ b/django-caretaker/caretaker/management/commands/pull_backup.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
 
         self._pull_backup(out_file=options.get('backup_local_file'),
                           remote_key=options.get('remote_key'),
-                          s3_client=s3, bucket_name=settings.BACKUP_BUCKET,
+                          s3_client=s3, bucket_name=settings.CARETAKER_BACKUP_BUCKET,
                           backup_version=options.get('backup_version'))
 
     @staticmethod

--- a/django-caretaker/caretaker/management/commands/push_backup.py
+++ b/django-caretaker/caretaker/management/commands/push_backup.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
 
         self._push_backup(backup_local_file=options.get('backup_local_file'),
                           remote_key=options.get('remote_key'),
-                          s3_client=s3, bucket_name=settings.BACKUP_BUCKET)
+                          s3_client=s3, bucket_name=settings.CARETAKER_BACKUP_BUCKET)
 
     def _push_backup(self, backup_local_file, remote_key, s3_client,
                      bucket_name):

--- a/django-caretaker/caretaker/management/commands/run_backup.py
+++ b/django-caretaker/caretaker/management/commands/run_backup.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
 
         self._run_backup(output_directory=options.get('output_directory'),
                          s3_client=s3,
-                         bucket_name=settings.BACKUP_BUCKET,
+                         bucket_name=settings.CARETAKER_BACKUP_BUCKET,
                          path_list=options.get('additional_files'))
 
     @staticmethod

--- a/django-caretaker/caretaker/settings.py
+++ b/django-caretaker/caretaker/settings.py
@@ -129,5 +129,6 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 AWS_ACCESS_KEY_ID = 'DEFAULT'
 AWS_SECRET_ACCESS_KEY = 'DEFAULT'
 AWS_DEFAULT_REGION = 'eu-west-2'
-BACKUP_BUCKET = 'caretakertestbackup'
-ADDITIONAL_BACKUP_PATHS = ['/home/martin/data', '/home/martin/Pics']
+
+CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
+CARETAKER_ADDITIONAL_BACKUP_PATHS = ['/home/martin/data', '/home/martin/Pics']

--- a/django-caretaker/caretaker/views.py
+++ b/django-caretaker/caretaker/views.py
@@ -42,7 +42,7 @@ def download_backup(request, backup_type, version_id):
         key = 'media.zip'
 
     response_object = io.BytesIO()
-    s3.download_fileobj(Bucket=settings.BACKUP_BUCKET, Key=key,
+    s3.download_fileobj(Bucket=settings.CARETAKER_BACKUP_BUCKET, Key=key,
                         Fileobj=response_object,
                         ExtraArgs={'VersionId': version_id})
     response_object.seek(0)
@@ -56,7 +56,7 @@ def download_backup(request, backup_type, version_id):
 
 def fetch_versions(s3, key):
     versions = s3.list_object_versions(
-        Bucket=settings.BACKUP_BUCKET, Prefix=key)
+        Bucket=settings.CARETAKER_BACKUP_BUCKET, Prefix=key)
 
     sql_versions = []
 


### PR DESCRIPTION
This renames the BACKUP_BUCKET and ADDITIONAL_BACKUP_PATHS to CARETAKER_BACKUP_BUCKET and CARETAKER_ADDITIONAL_BACKUP_PATHS.

Fixes #7