### PR TITLE
Allow for multiple backend providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # django-caretaker
-django-caretaker ('The Caretaker') is a Django app that backs up your database and media files to a versioned AWS S3 bucket. It comes with the Terraform files to provision the S3 bucket and provides management commands to schedule regular backups.
+django-caretaker ('The Caretaker') is a Django app that backs up your database and media files to a versioned remote object store, such as an AWS S3 bucket. It comes with the Terraform files to provision the required cloud infrastructures (e.g. S3 bucket) and provides management commands to schedule regular backups.
 
 ![license](https://img.shields.io/github/license/martinpauleve/django-caretaker) ![activity](https://img.shields.io/github/last-commit/MartinPaulEve/django-caretaker) 
 
@@ -16,9 +16,14 @@ Add 'caretaker' to your installed apps in your Django settings file.
 
 Add 'path('caretaker/', include('caretaker.urls')),' to your urls.py file to enable the /caretaker/list view.
 
+django-caretaker requires Python 3.10+ as it makes use of newer language features.
+
 ## Setup and Configuration
-### Configure an AWS S3 Bucket and IAM User for Backup
-Next, ensure that you have a working AWS cli client and configure it if not.
+### Configure a backend and access rights
+django-caretaker has the ability to support multiple cloud-based object store backends. However, at the moment, the only backend provider that we have is for Amazon S3. This will expand as the project grows.
+
+#### Amazon S3 / IAM
+Ensure that you have a working AWS cli client and configure it if not.
 
 Set the BACKUP_BUCKET variable in your settings.py file. This must be a globally unique name for the S3 bucket. You should also set the MEDIA_ROOT folder so that we know what to back up:
 
@@ -55,21 +60,22 @@ Caretaker provides a number of management commands that can be accessed from man
 ### Run Backup
 This is the most important command. It backs up your database and your media files to the remote store.
 
-    usage: manage.py run_backup [-h] [--output-directory OUTPUT_DIRECTORY] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
+    usage: manage.py run_backup [-h] [--output-directory OUTPUT_DIRECTORY] [-a ADDITIONAL_FILES] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
+                            [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
     
-    Creates a backup set and pushes it to S3
+    Creates a backup set and pushes it to the remote store
 
 Example usage:
 
-    manage.py run_backup --output-directory=~/backup
+    manage.py run_backup --output-directory=~/backup -a /home/user/dir1 -a /home/user/dir2
 
 ### Push Backup
 This command pushes a backup to the server.
 
-    usage: manage.py push_backup [-h] [--backup-local-file BACKUP_LOCAL_FILE] [--remote-key REMOTE_KEY] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
-                                 [--skip-checks]
+    usage: manage.py push_backup [-h] [--backup-local-file BACKUP_LOCAL_FILE] [--remote-key REMOTE_KEY] [--version] [-v {0,1,2,3}]
+                             [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
     
-    Pushes the backup SQL to the S3 store
+    Pushes the backup SQL to the remote store
 
 Example usage:
 
@@ -78,10 +84,11 @@ Example usage:
 ### Pull Backup
 This command retrieves a backup file from the server. You must also specify the version you wish to retrieve.
 
-    usage: manage.py pull_backup [-h] [--backup-version BACKUP_VERSION] [--out-file OUT_FILE] [--remote-key REMOTE_KEY] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color]
-                                 [--force-color] [--skip-checks]
+    usage: manage.py pull_backup [-h] [--backup-version BACKUP_VERSION] [--out-file OUT_FILE] [--remote-key REMOTE_KEY] [--version]
+                             [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
+                             [--skip-checks]
     
-    Pulls a specific backup SQL from the S3 store
+    Pulls a specific backup SQL from the remote store
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ Set the BACKUP_BUCKET variable in your settings.py file. This must be a globally
 
     CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
     CARETAKER_ADDITIONAL_BACKUP_PATHS = ['/home/user/path1', '/home/user/path2']
+    CARETAKER_BACKEND = 'Amazon S3'
+    CARETAKER_BACKENDS = ['caretaker.backend.backends.s3']
     MEDIA_ROOT = '/var/www/media'
+
+The CARETAKER_BACKENDS list allows you to specify the available backends. The CARETAKER_BACKEND variable selects the backend to use (there is only S3 at the moment).
 
 Generate and run Terraform configuration in your home directory:
 

--- a/django-caretaker/README.md
+++ b/django-caretaker/README.md
@@ -1,5 +1,5 @@
 # django-caretaker
-django-caretaker ('The Caretaker') is a Django app that backs up your database and media files to a versioned AWS S3 bucket. It comes with the Terraform files to provision the S3 bucket and provides management commands to schedule regular backups.
+django-caretaker ('The Caretaker') is a Django app that backs up your database and media files to a versioned remote object store, such as an AWS S3 bucket. It comes with the Terraform files to provision the required cloud infrastructures (e.g. S3 bucket) and provides management commands to schedule regular backups.
 
 ![license](https://img.shields.io/github/license/martinpauleve/django-caretaker) ![activity](https://img.shields.io/github/last-commit/MartinPaulEve/django-caretaker) 
 
@@ -16,9 +16,14 @@ Add 'caretaker' to your installed apps in your Django settings file.
 
 Add 'path('caretaker/', include('caretaker.urls')),' to your urls.py file to enable the /caretaker/list view.
 
+django-caretaker requires Python 3.10+ as it makes use of newer language features.
+
 ## Setup and Configuration
-### Configure an AWS S3 Bucket and IAM User for Backup
-Next, ensure that you have a working AWS cli client and configure it if not.
+### Configure a backend and access rights
+django-caretaker has the ability to support multiple cloud-based object store backends. However, at the moment, the only backend provider that we have is for Amazon S3. This will expand as the project grows.
+
+#### Amazon S3 / IAM
+Ensure that you have a working AWS cli client and configure it if not.
 
 Set the BACKUP_BUCKET variable in your settings.py file. This must be a globally unique name for the S3 bucket. You should also set the MEDIA_ROOT folder so that we know what to back up:
 
@@ -55,21 +60,22 @@ Caretaker provides a number of management commands that can be accessed from man
 ### Run Backup
 This is the most important command. It backs up your database and your media files to the remote store.
 
-    usage: manage.py run_backup [-h] [--output-directory OUTPUT_DIRECTORY] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
+    usage: manage.py run_backup [-h] [--output-directory OUTPUT_DIRECTORY] [-a ADDITIONAL_FILES] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
+                            [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
     
-    Creates a backup set and pushes it to S3
+    Creates a backup set and pushes it to the remote store
 
 Example usage:
 
-    manage.py run_backup --output-directory=~/backup
+    manage.py run_backup --output-directory=~/backup -a /home/user/dir1 -a /home/user/dir2
 
 ### Push Backup
 This command pushes a backup to the server.
 
-    usage: manage.py push_backup [-h] [--backup-local-file BACKUP_LOCAL_FILE] [--remote-key REMOTE_KEY] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
-                                 [--skip-checks]
+    usage: manage.py push_backup [-h] [--backup-local-file BACKUP_LOCAL_FILE] [--remote-key REMOTE_KEY] [--version] [-v {0,1,2,3}]
+                             [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
     
-    Pushes the backup SQL to the S3 store
+    Pushes the backup SQL to the remote store
 
 Example usage:
 
@@ -78,10 +84,11 @@ Example usage:
 ### Pull Backup
 This command retrieves a backup file from the server. You must also specify the version you wish to retrieve.
 
-    usage: manage.py pull_backup [-h] [--backup-version BACKUP_VERSION] [--out-file OUT_FILE] [--remote-key REMOTE_KEY] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color]
-                                 [--force-color] [--skip-checks]
+    usage: manage.py pull_backup [-h] [--backup-version BACKUP_VERSION] [--out-file OUT_FILE] [--remote-key REMOTE_KEY] [--version]
+                             [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
+                             [--skip-checks]
     
-    Pulls a specific backup SQL from the S3 store
+    Pulls a specific backup SQL from the remote store
 
 Example:
 

--- a/django-caretaker/README.md
+++ b/django-caretaker/README.md
@@ -24,7 +24,11 @@ Set the BACKUP_BUCKET variable in your settings.py file. This must be a globally
 
     CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
     CARETAKER_ADDITIONAL_BACKUP_PATHS = ['/home/user/path1', '/home/user/path2']
+    CARETAKER_BACKEND = 'Amazon S3'
+    CARETAKER_BACKENDS = ['caretaker.backend.backends.s3']
     MEDIA_ROOT = '/var/www/media'
+
+The CARETAKER_BACKENDS list allows you to specify the available backends. The CARETAKER_BACKEND variable selects the backend to use (there is only S3 at the moment).
 
 Generate and run Terraform configuration in your home directory:
 

--- a/django-caretaker/caretaker/backend/abstract_backend.py
+++ b/django-caretaker/caretaker/backend/abstract_backend.py
@@ -1,0 +1,114 @@
+import abc
+import importlib
+import logging
+import sys
+from enum import Enum
+from pathlib import Path
+
+from django.conf import settings
+
+
+class StoreOutcome(Enum):
+    FAILED = 0
+    STORED = 1
+    IDENTICAL = 2
+
+
+class AbstractBackend(metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    def __init__(self, logger: logging.Logger | None = None):
+        self.logger = logger
+
+    @property
+    @abc.abstractmethod
+    def backend_name(self) -> str:
+        """
+        The display name of the backend
+        :return: a string of the backend name
+        """
+        pass
+
+    @abc.abstractmethod
+    def versions(self, bucket_name: str, remote_key: str = '') -> list[dict]:
+        """
+        List the versions of an object
+        :param remote_key: the remote key to list
+        :param bucket_name: the remote bucket name
+        :return: a list of dictionaries containing 'version_id' and
+        'last_modified'
+        """
+        pass
+
+    @abc.abstractmethod
+    def store_object(self, local_file: Path, bucket_name: str,
+                     remote_key: str, check_identical: bool) -> StoreOutcome:
+        """
+        Store an object remotely
+        :param local_file: the local file to store
+        :param bucket_name: the remote bucket name
+        :param remote_key: the remote key of the object
+        :param check_identical: whether to check if the last version is already
+        the same as this version
+        :return: a response enum StoreOutcome
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_object(self, bucket_name: str, remote_key: str,
+                   version_id: str) -> bytes | None:
+        """
+        Retrieve an object from the remote store as bytes
+        :param bucket_name: the remote bucket name
+        :param remote_key: the remote key of the object
+        :param version_id: the version ID to fetch
+        :return: the bytes of the retrieved object
+        """
+        pass
+
+    @abc.abstractmethod
+    def download_object(self, local_file: Path, bucket_name: str,
+                        remote_key: str, version_id: str) -> bool:
+        """
+        Retrieve an object from the remote store and save it to a file
+        :param local_file: the location to store the local file
+        :param bucket_name: the remote bucket name
+        :param remote_key: the remote key of the object
+        :param version_id: the version ID to fetch
+        :return: a true/false boolean of success
+        """
+        pass
+
+
+class BackendFactory:
+    @staticmethod
+    def get_backend(backend_name: str = '') -> AbstractBackend | None:
+        # see if there's a list of backends in the settings file
+        # if there is, use it
+        backends = ['caretaker.backend.backends.s3']
+
+        if hasattr(settings, 'CARETAKER_BACKENDS') and \
+                settings.CARETAKER_BACKENDS:
+            backends = settings.CARETAKER_BACKENDS
+
+        # get the backend name in this order:
+        # 1. passed to function
+        # 2. passed to settings.py
+        if backend_name == '':
+            backend_name = settings.CARETAKER_BACKEND
+
+        # dynamically load modules in the backends space
+        for full_package_name in backends:
+            if full_package_name not in sys.modules:
+                module = importlib.import_module(full_package_name)
+                backend = module.get_backend()
+
+                if backend.backend_name == backend_name:
+                    return backend
+            else:
+                backend = sys.modules[full_package_name].get_backend()
+
+                if backend.backend_name == backend_name:
+                    return backend
+
+        return None

--- a/django-caretaker/caretaker/backend/backends/s3.py
+++ b/django-caretaker/caretaker/backend/backends/s3.py
@@ -1,0 +1,136 @@
+import filecmp
+import logging
+import tempfile
+from pathlib import Path
+
+import boto3
+import botocore.exceptions
+from django.conf import settings
+
+from caretaker.main_utils import log
+from caretaker.backend.abstract_backend import AbstractBackend, StoreOutcome
+
+
+def get_backend():
+    return S3Backend()
+
+
+class S3Backend(AbstractBackend):
+    def __init__(self, logger: logging.Logger | None = None):
+        super().__init__(logger)
+
+        self.logger = log.get_logger('caretaker-amazon-s3')
+
+        self.s3 = boto3.client(
+            's3',
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+    @property
+    def backend_name(self) -> str:
+        return 'Amazon S3'
+
+    def versions(self, bucket_name: str, remote_key: str = '') -> list[dict]:
+        try:
+            versions = self.s3.list_object_versions(Bucket=bucket_name,
+                                                    Prefix=remote_key)
+
+            if versions and 'Versions' in versions:
+                final_versions = [
+                    {'version_id': item['VersionId'],
+                     'last_modified': item['LastModified'],
+                     'size': item['Size']
+                     } for item in versions['Versions']
+                ]
+                return final_versions
+            else:
+                return []
+        except botocore.exceptions.ClientError as ce:
+            self.logger.error(
+                'Unable to retrieve version list of {} from {} in {} '
+                '({})'.format(remote_key, bucket_name, self.backend_name, ce)
+            )
+            return []
+
+    def store_object(self, local_file: Path, bucket_name: str,
+                     remote_key: str, check_identical: bool) -> StoreOutcome:
+
+        if check_identical:
+            # download the latest version of the backup to see if it's the same
+            # as the local file
+            try:
+                with tempfile.TemporaryDirectory() as tmp:
+                    path = Path(tmp) / 'latest'
+
+                    self.s3.download_file(Filename=str(path),
+                                          Bucket=bucket_name,
+                                          Key=remote_key)
+
+                    # byte-by-byte comparison
+                    # may be slow on big files
+                    if filecmp.cmp(path, local_file):
+                        self.logger.info(
+                            'Latest backup is equal to remote S3 version')
+                        return StoreOutcome.IDENTICAL
+
+            except botocore.exceptions.ClientError:
+                self.logger.debug('There was a problem comparing the previous '
+                                  'version of this object with the stored '
+                                  'version. This is not a fatal error and '
+                                  'can be caused by this being the first '
+                                  'stored version of an object.')
+
+        try:
+            # upload the latest version to S3
+            self.s3.upload_file(Filename=str(local_file),
+                                Bucket=bucket_name, Key=remote_key)
+
+            self.logger.info('Backup {} stored as {}'.format(
+                local_file, remote_key))
+        except botocore.exceptions.ClientError:
+            self.logger.error('There was a problem storing the backup.')
+            return StoreOutcome.FAILED
+
+        return StoreOutcome.STORED
+
+    def get_object(self, bucket_name: str, remote_key: str,
+                   version_id: str) -> bytes | None:
+        try:
+            result = self.s3.get_object(Bucket=bucket_name, Key=remote_key,
+                                        VersionId=version_id)
+
+            self.logger.info('Fetching version {} of {}'.format(
+                version_id,
+                remote_key
+            ))
+
+            return result['Body'].read()
+
+        except botocore.exceptions.ClientError:
+            self.logger.error('Unable to download version {} of '
+                              '{}'.format(version_id, remote_key))
+            return None
+
+    def download_object(self, local_file: Path, bucket_name: str,
+                        remote_key: str, version_id: str) -> bool:
+        # normalize path
+        out_file = Path(local_file).expanduser()
+
+        try:
+            self.s3.download_file(Filename=str(out_file),
+                                  Bucket=bucket_name,
+                                  Key=remote_key,
+                                  ExtraArgs={'VersionId': version_id})
+
+            self.logger.info('Saved version {} of {} to {}'.format(
+                version_id,
+                remote_key,
+                out_file
+            ))
+
+            return True
+        except botocore.exceptions.ClientError:
+            self.logger.error('Unable to download version {} of '
+                              '{} to {}'.format(version_id, remote_key,
+                                                out_file))
+            return False

--- a/django-caretaker/caretaker/management/commands/create_backup.py
+++ b/django-caretaker/caretaker/management/commands/create_backup.py
@@ -26,12 +26,12 @@ class Command(BaseCommand):
         Creates a local backup set
         """
 
-        self._create_backup(output_directory=options.get('output_directory'),
-                            path_list=options.get('additional_files'))
+        self.create_backup(output_directory=options.get('output_directory'),
+                           path_list=options.get('additional_files'))
 
     @staticmethod
-    def _create_backup(output_directory, data_file='data.json',
-                       archive_file='media.zip', path_list=None):
+    def create_backup(output_directory, data_file='data.json',
+                      archive_file='media.zip', path_list=None):
         logger = log.get_logger('caretaker')
 
         if not output_directory:

--- a/django-caretaker/caretaker/management/commands/get_terraform.py
+++ b/django-caretaker/caretaker/management/commands/get_terraform.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
                 out_file.write(rendered)
 
     @staticmethod
-    def _generate_terraform(output_directory):
+    def generate_terraform(output_directory):
         logger = log.get_logger('caretaker')
         output_directory = Path(output_directory).expanduser()
 
@@ -58,4 +58,4 @@ class Command(BaseCommand):
         """
         Produces a Terraform setup configuration
         """
-        self._generate_terraform(options.get('output_directory'))
+        self.generate_terraform(options.get('output_directory'))

--- a/django-caretaker/caretaker/management/commands/install_cron.py
+++ b/django-caretaker/caretaker/management/commands/install_cron.py
@@ -27,12 +27,12 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Installs Cron jobs
         """
-        self._install_cron(job_name=settings.CARETAKER_BACKUP_BUCKET,
-                           action=options.get('action'),
-                           base_dir=settings.BASE_DIR)
+        self.install_cron(job_name=settings.CARETAKER_BACKUP_BUCKET,
+                          action=options.get('action'),
+                          base_dir=settings.BASE_DIR)
 
     @staticmethod
-    def _install_cron(job_name, action, base_dir):
+    def install_cron(job_name, action, base_dir):
         logger = log.get_logger('caretaker')
         tab = CronTab(user=True)
         virtualenv = os.environ.get('VIRTUAL_ENV', None)

--- a/django-caretaker/caretaker/management/commands/list_backups.py
+++ b/django-caretaker/caretaker/management/commands/list_backups.py
@@ -1,7 +1,8 @@
-import boto3
 import humanize
 from django.conf import settings
 from django.core.management.base import BaseCommand
+
+from caretaker.backend.abstract_backend import BackendFactory
 from caretaker.main_utils import log
 
 
@@ -19,30 +20,29 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Lists available backups"""
 
-        s3 = boto3.client('s3',
-                          aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                          aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+        backend = BackendFactory.get_backend()
 
-        self._list_backups(s3_client=s3, remote_key=options.get('remote_key'),
+        if not backend:
+            logger = log.get_logger('caretaker')
+            logger.error('Unable to find a valid backend.')
+            return
+
+        self._list_backups(backend=backend,
+                           remote_key=options.get('remote_key'),
                            bucket_name=settings.CARETAKER_BACKUP_BUCKET)
 
     @staticmethod
-    def _list_backups(remote_key, s3_client, bucket_name):
+    def _list_backups(remote_key, backend, bucket_name) -> list[dict]:
         logger = log.get_logger('caretaker')
 
-        s3 = s3_client
+        results = backend.versions(remote_key=remote_key,
+                                   bucket_name=bucket_name)
 
-        versions = s3.list_object_versions(Bucket=bucket_name,
-                                           Prefix=remote_key)
+        for item in results:
+            logger.info('Backup from {}: {} [{}]'.format(
+                item['last_modified'],
+                item['version_id'],
+                humanize.naturalsize(item['size'])
+            ))
 
-        if versions and 'Versions' in versions:
-            for item in versions['Versions']:
-                logger.info('Backup from {}: {} [{}]'.format(
-                    item['LastModified'],
-                    item['VersionId'],
-                    humanize.naturalsize(item['Size'])
-                ))
-
-            return versions['Versions']
-
-        return None
+        return results

--- a/django-caretaker/caretaker/management/commands/list_backups.py
+++ b/django-caretaker/caretaker/management/commands/list_backups.py
@@ -27,12 +27,12 @@ class Command(BaseCommand):
             logger.error('Unable to find a valid backend.')
             return
 
-        self._list_backups(backend=backend,
-                           remote_key=options.get('remote_key'),
-                           bucket_name=settings.CARETAKER_BACKUP_BUCKET)
+        self.list_backups(backend=backend,
+                          remote_key=options.get('remote_key'),
+                          bucket_name=settings.CARETAKER_BACKUP_BUCKET)
 
     @staticmethod
-    def _list_backups(remote_key, backend, bucket_name) -> list[dict]:
+    def list_backups(remote_key, backend, bucket_name) -> list[dict]:
         logger = log.get_logger('caretaker')
 
         results = backend.versions(remote_key=remote_key,

--- a/django-caretaker/caretaker/management/commands/pull_backup.py
+++ b/django-caretaker/caretaker/management/commands/pull_backup.py
@@ -1,10 +1,8 @@
-from pathlib import Path
-
-import boto3
 from botocore.exceptions import ClientError
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from caretaker.backend.abstract_backend import BackendFactory
 from caretaker.main_utils import log
 
 
@@ -25,43 +23,40 @@ class Command(BaseCommand):
         """
         Pulls a backup from S3
         """
-        s3 = boto3.client('s3',
-                          aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                          aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+        backend = BackendFactory.get_backend()
+
+        if not backend:
+            logger = log.get_logger('caretaker')
+            logger.error('Unable to find a valid backend.')
+            return
 
         self._pull_backup(out_file=options.get('backup_local_file'),
                           remote_key=options.get('remote_key'),
-                          s3_client=s3, bucket_name=settings.CARETAKER_BACKUP_BUCKET,
+                          backend=backend,
+                          bucket_name=settings.CARETAKER_BACKUP_BUCKET,
                           backup_version=options.get('backup_version'))
 
     @staticmethod
-    def _pull_backup(backup_version, out_file, remote_key, s3_client,
+    def _pull_backup(backup_version, out_file, remote_key, backend,
                      bucket_name):
         logger = log.get_logger('caretaker')
 
-        s3 = s3_client
-
-        out_file = Path(out_file).expanduser()
+        download = backend.download_object(local_file=out_file,
+                                           remote_key=remote_key,
+                                           version_id=backup_version,
+                                           bucket_name=bucket_name)
 
         try:
-            s3.download_file(
-                Filename=str(out_file),
-                Bucket=bucket_name,
-                Key=remote_key,
-                ExtraArgs={'VersionId': backup_version}
-            )
+            if download:
 
-            logger.info('Saved version {} of {} to {}'.format(
-                backup_version,
-                remote_key,
-                out_file
-            ))
-
-            return out_file
+                return out_file
+            else:
+                raise ClientError
         except ClientError:
             logger.error('Unable to download version {} of {} to {}'.format(
                 backup_version,
                 remote_key,
                 out_file
             ))
+
             return None

--- a/django-caretaker/caretaker/management/commands/pull_backup.py
+++ b/django-caretaker/caretaker/management/commands/pull_backup.py
@@ -30,15 +30,15 @@ class Command(BaseCommand):
             logger.error('Unable to find a valid backend.')
             return
 
-        self._pull_backup(out_file=options.get('backup_local_file'),
-                          remote_key=options.get('remote_key'),
-                          backend=backend,
-                          bucket_name=settings.CARETAKER_BACKUP_BUCKET,
-                          backup_version=options.get('backup_version'))
+        self.pull_backup(out_file=options.get('backup_local_file'),
+                         remote_key=options.get('remote_key'),
+                         backend=backend,
+                         bucket_name=settings.CARETAKER_BACKUP_BUCKET,
+                         backup_version=options.get('backup_version'))
 
     @staticmethod
-    def _pull_backup(backup_version, out_file, remote_key, backend,
-                     bucket_name):
+    def pull_backup(backup_version, out_file, remote_key, backend,
+                    bucket_name):
         logger = log.get_logger('caretaker')
 
         download = backend.download_object(local_file=out_file,

--- a/django-caretaker/caretaker/management/commands/pull_backup.py
+++ b/django-caretaker/caretaker/management/commands/pull_backup.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
     Installs cron tasks.
     """
 
-    help = "Pulls a specific backup from the S3 store"
+    help = "Pulls a specific backup from the remote store"
 
     def add_arguments(self, parser):
         parser.add_argument('--backup-version')

--- a/django-caretaker/caretaker/management/commands/push_backup.py
+++ b/django-caretaker/caretaker/management/commands/push_backup.py
@@ -37,7 +37,8 @@ class Command(BaseCommand):
 
         self._push_backup(backup_local_file=options.get('backup_local_file'),
                           remote_key=options.get('remote_key'),
-                          s3_client=s3, bucket_name=settings.CARETAKER_BACKUP_BUCKET)
+                          s3_client=s3,
+                          bucket_name=settings.CARETAKER_BACKUP_BUCKET)
 
     def _push_backup(self, backup_local_file, remote_key, s3_client,
                      bucket_name):

--- a/django-caretaker/caretaker/management/commands/push_backup.py
+++ b/django-caretaker/caretaker/management/commands/push_backup.py
@@ -14,10 +14,6 @@ class Command(BaseCommand):
 
     help = "Pushes the backup to the S3 store"
 
-    returns = {0: 'FAILED',
-               1: 'STORED',
-               2: 'IDENTICAL'}
-
     def add_arguments(self, parser):
         parser.add_argument('--backup-local-file',
                             default='~/backup.sql')

--- a/django-caretaker/caretaker/management/commands/push_backup.py
+++ b/django-caretaker/caretaker/management/commands/push_backup.py
@@ -32,14 +32,14 @@ class Command(BaseCommand):
             logger.error('Unable to find a valid backend.')
             return
 
-        self._push_backup(backup_local_file=options.get('backup_local_file'),
-                          remote_key=options.get('remote_key'),
-                          backend=backend,
-                          bucket_name=settings.CARETAKER_BACKUP_BUCKET)
+        self.push_backup(backup_local_file=options.get('backup_local_file'),
+                         remote_key=options.get('remote_key'),
+                         backend=backend,
+                         bucket_name=settings.CARETAKER_BACKUP_BUCKET)
 
     @staticmethod
-    def _push_backup(backup_local_file, remote_key, backend,
-                     bucket_name):
+    def push_backup(backup_local_file, remote_key, backend,
+                    bucket_name):
 
         logger = log.get_logger('caretaker')
 

--- a/django-caretaker/caretaker/management/commands/push_backup.py
+++ b/django-caretaker/caretaker/management/commands/push_backup.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
     Installs cron tasks.
     """
 
-    help = "Pushes the backup to the S3 store"
+    help = "Pushes the backup to the remote store"
 
     def add_arguments(self, parser):
         parser.add_argument('--backup-local-file',

--- a/django-caretaker/caretaker/management/commands/run_backup.py
+++ b/django-caretaker/caretaker/management/commands/run_backup.py
@@ -33,15 +33,15 @@ class Command(BaseCommand):
             logger.error('Unable to find a valid backend.')
             return
 
-        self._run_backup(output_directory=options.get('output_directory'),
-                         backend=backend,
-                         bucket_name=settings.CARETAKER_BACKUP_BUCKET,
-                         path_list=options.get('additional_files'))
+        self.run_backup(output_directory=options.get('output_directory'),
+                        backend=backend,
+                        bucket_name=settings.CARETAKER_BACKUP_BUCKET,
+                        path_list=options.get('additional_files'))
 
     @staticmethod
-    def _run_backup(output_directory, data_file='data.json',
-                    archive_file='media.zip', path_list=None,
-                    backend=None, bucket_name=None):
+    def run_backup(output_directory, data_file='data.json',
+                   archive_file='media.zip', path_list=None,
+                   backend=None, bucket_name=None):
         logger = log.get_logger('caretaker')
 
         if not path_list:
@@ -56,19 +56,19 @@ class Command(BaseCommand):
             # create a local backup set in this temporary directory
             create_command = CreateCommand()
 
-            json_file, zip_file = create_command._create_backup(
+            json_file, zip_file = create_command.create_backup(
                 output_directory=temporary_directory_name,
                 path_list=path_list
             )
 
             # push the data
             push_command = PushCommand()
-            push_command._push_backup(backup_local_file=json_file,
-                                      remote_key=data_file,
-                                      backend=backend, bucket_name=bucket_name)
-            push_command._push_backup(backup_local_file=zip_file,
-                                      remote_key=archive_file,
-                                      backend=backend, bucket_name=bucket_name)
+            push_command.push_backup(backup_local_file=json_file,
+                                     remote_key=data_file,
+                                     backend=backend, bucket_name=bucket_name)
+            push_command.push_backup(backup_local_file=zip_file,
+                                     remote_key=archive_file,
+                                     backend=backend, bucket_name=bucket_name)
 
             logger.info('Pushed backups to remote store')
             return json_file, archive_file

--- a/django-caretaker/caretaker/management/commands/run_backup.py
+++ b/django-caretaker/caretaker/management/commands/run_backup.py
@@ -3,6 +3,8 @@ import tempfile
 import boto3
 from django.conf import settings
 from django.core.management.base import BaseCommand
+
+from caretaker.backend.abstract_backend import BackendFactory
 from caretaker.management.commands.create_backup import Command as CreateCommand
 from caretaker.management.commands.push_backup import Command as PushCommand
 
@@ -25,22 +27,24 @@ class Command(BaseCommand):
         """
         Creates a backup set and pushes it to S3
         """
-        s3 = boto3.client('s3',
-                          aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                          aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+        backend = BackendFactory.get_backend()
+
+        if not backend:
+            logger = log.get_logger('caretaker')
+            logger.error('Unable to find a valid backend.')
+            return
 
         self._run_backup(output_directory=options.get('output_directory'),
-                         s3_client=s3,
+                         backend=backend,
                          bucket_name=settings.CARETAKER_BACKUP_BUCKET,
                          path_list=options.get('additional_files'))
 
     @staticmethod
     def _run_backup(output_directory, data_file='data.json',
                     archive_file='media.zip', path_list=None,
-                    s3_client=None, bucket_name=None):
+                    backend=None, bucket_name=None):
         logger = log.get_logger('caretaker')
-
-        s3 = s3_client
 
         if not path_list:
             path_list = []
@@ -63,10 +67,10 @@ class Command(BaseCommand):
             push_command = PushCommand()
             push_command._push_backup(backup_local_file=json_file,
                                       remote_key=data_file,
-                                      s3_client=s3, bucket_name=bucket_name)
+                                      backend=backend, bucket_name=bucket_name)
             push_command._push_backup(backup_local_file=zip_file,
                                       remote_key=archive_file,
-                                      s3_client=s3, bucket_name=bucket_name)
+                                      backend=backend, bucket_name=bucket_name)
 
             logger.info('Pushed backups to remote store')
             return json_file, archive_file

--- a/django-caretaker/caretaker/management/commands/run_backup.py
+++ b/django-caretaker/caretaker/management/commands/run_backup.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
     Installs cron tasks.
     """
 
-    help = "Creates a backup set and pushes it to S3"
+    help = "Creates a backup set and pushes it to the remote store"
 
     def add_arguments(self, parser):
         parser.add_argument('--output-directory')

--- a/django-caretaker/caretaker/management/commands/run_backup.py
+++ b/django-caretaker/caretaker/management/commands/run_backup.py
@@ -1,14 +1,12 @@
 import tempfile
 
-import boto3
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from caretaker.backend.abstract_backend import BackendFactory
+from caretaker.main_utils import log
 from caretaker.management.commands.create_backup import Command as CreateCommand
 from caretaker.management.commands.push_backup import Command as PushCommand
-
-from caretaker.main_utils import log
 
 
 class Command(BaseCommand):

--- a/django-caretaker/caretaker/settings.py
+++ b/django-caretaker/caretaker/settings.py
@@ -133,3 +133,4 @@ AWS_DEFAULT_REGION = 'eu-west-2'
 CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
 CARETAKER_ADDITIONAL_BACKUP_PATHS = ['/home/martin/data', '/home/martin/Pics']
 CARETAKER_BACKEND = 'Amazon S3'
+CARETAKER_BACKENDS = ['caretaker.backend.backends.s3']

--- a/django-caretaker/caretaker/settings.py
+++ b/django-caretaker/caretaker/settings.py
@@ -132,3 +132,4 @@ AWS_DEFAULT_REGION = 'eu-west-2'
 
 CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
 CARETAKER_ADDITIONAL_BACKUP_PATHS = ['/home/martin/data', '/home/martin/Pics']
+CARETAKER_BACKEND = 'Amazon S3'

--- a/django-caretaker/caretaker/tests/commands/test_create_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_create_backup_s3.py
@@ -41,7 +41,7 @@ class TestCreateBackup(TestCase):
             self.assertTrue(result == StoreOutcome.STORED)
 
             # create a backup record including this directory
-            json_file, data_file = self.create_command._create_backup(
+            json_file, data_file = self.create_command.create_backup(
                 output_directory=temporary_directory_name,
                 path_list=[temporary_directory_name]
             )

--- a/django-caretaker/caretaker/tests/commands/test_create_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_create_backup_s3.py
@@ -5,14 +5,15 @@ import django
 from django.test import TestCase
 from moto import mock_s3
 
+from caretaker.backend.abstract_backend import StoreOutcome
 from caretaker.management.commands.create_backup import Command as CreateCommand
-from caretaker.tests.utils import setup_bucket, upload_temporary_file
+from caretaker.tests.utils import setup_test_class_s3, upload_temporary_file
 
 
 @mock_s3
 class TestCreateBackup(TestCase):
     def setUp(self):
-        setup_bucket(self)
+        setup_test_class_s3(self)
 
         self.logger.info('Setup for create_backup')
 
@@ -37,7 +38,7 @@ class TestCreateBackup(TestCase):
                 temporary_directory_name=temporary_directory_name,
                 contents=self.test_contents)
 
-            self.assertTrue(result == self.command.returns[1])
+            self.assertTrue(result == StoreOutcome.STORED)
 
             # create a backup record including this directory
             json_file, data_file = self.create_command._create_backup(

--- a/django-caretaker/caretaker/tests/commands/test_get_terraform.py
+++ b/django-caretaker/caretaker/tests/commands/test_get_terraform.py
@@ -25,7 +25,7 @@ class TestTerraformOutput(TestCase):
     def test_terraform(self):
         self.logger.info('Running Terraform test')
         with tempfile.TemporaryDirectory() as temporary_directory_name:
-            self.command._generate_terraform(
+            self.command.generate_terraform(
                 output_directory=temporary_directory_name)
 
             self.assertTrue(

--- a/django-caretaker/caretaker/tests/commands/test_get_terraform.py
+++ b/django-caretaker/caretaker/tests/commands/test_get_terraform.py
@@ -6,13 +6,13 @@ from moto import mock_s3
 
 from caretaker.management.commands.get_terraform import Command as \
     TerraformCommand
-from caretaker.tests.utils import setup_bucket
+from caretaker.tests.utils import setup_test_class_s3
 
 
 @mock_s3
 class TestTerraformOutput(TestCase):
     def setUp(self):
-        setup_bucket(self)
+        setup_test_class_s3(self)
 
         self.logger.info('Setup for Terraform test')
 

--- a/django-caretaker/caretaker/tests/commands/test_list_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_list_backup_s3.py
@@ -25,7 +25,7 @@ class TestListBackups(TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory_name:
 
             # first test that we get nothing back
-            result = self.list_command._list_backups(
+            result = self.list_command.list_backups(
                 remote_key=self.json_key, bucket_name=self.bucket_name,
                 backend=self.backend
             )
@@ -39,7 +39,7 @@ class TestListBackups(TestCase):
                 contents=self.test_contents)
 
             # Now check that we get a result
-            result = self.list_command._list_backups(
+            result = self.list_command.list_backups(
                 remote_key=self.json_key, bucket_name=self.bucket_name,
                 backend=self.backend
             )
@@ -58,7 +58,7 @@ class TestListBackups(TestCase):
                 contents='test2')
 
             # first test that we get nothing back
-            result = self.list_command._list_backups(
+            result = self.list_command.list_backups(
                 remote_key=self.json_key, bucket_name=self.bucket_name,
                 backend=self.backend
             )
@@ -73,11 +73,11 @@ class TestListBackups(TestCase):
 
             # now run a final time with the same version and check that
             # the latest version is the same
-            self.command._push_backup(
+            self.command.push_backup(
                 backup_local_file=temporary_file, remote_key=self.json_key,
                 backend=self.backend, bucket_name=self.bucket_name)
 
-            result = self.list_command._list_backups(
+            result = self.list_command.list_backups(
                 remote_key=self.json_key, bucket_name=self.bucket_name,
                 backend=self.backend
             )

--- a/django-caretaker/caretaker/tests/commands/test_list_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_list_backup_s3.py
@@ -5,19 +5,17 @@ from moto import mock_s3
 
 from caretaker.backend.abstract_backend import BackendFactory
 from caretaker.management.commands.list_backups import Command as ListCommand
-from caretaker.tests.utils import setup_bucket, upload_temporary_file
+from caretaker.tests.utils import setup_test_class_s3, upload_temporary_file
 
 
 @mock_s3
 class TestListBackups(TestCase):
     def setUp(self):
-        setup_bucket(self)
+        setup_test_class_s3(self)
 
         self.logger.info('Setup list_backups S3')
 
         self.list_command = ListCommand()
-
-        self.backend = BackendFactory.get_backend('Amazon S3')
 
     def tearDown(self):
         self.logger.info('Teardown list_backups S3')
@@ -78,7 +76,7 @@ class TestListBackups(TestCase):
             # the latest version is the same
             self.command._push_backup(
                 backup_local_file=temporary_file, remote_key=self.json_key,
-                s3_client=self.client, bucket_name=self.bucket_name)
+                backend=self.backend, bucket_name=self.bucket_name)
 
             result = self.list_command._list_backups(
                 remote_key=self.json_key, bucket_name=self.bucket_name,

--- a/django-caretaker/caretaker/tests/commands/test_list_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_list_backup_s3.py
@@ -3,7 +3,6 @@ import tempfile
 from django.test import TestCase
 from moto import mock_s3
 
-from caretaker.backend.abstract_backend import BackendFactory
 from caretaker.management.commands.list_backups import Command as ListCommand
 from caretaker.tests.utils import setup_test_class_s3, upload_temporary_file
 

--- a/django-caretaker/caretaker/tests/commands/test_pull_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_pull_backup_s3.py
@@ -53,7 +53,7 @@ class TestPullBackup(TestCase):
                 backup_version=result[0]['version_id'],
                 remote_key=self.json_key,
                 bucket_name=self.bucket_name,
-                s3_client=self.client,
+                backend=self.backend,
                 out_file=download_location
             )
 
@@ -97,7 +97,7 @@ class TestPullBackup(TestCase):
                 backup_version=result[0]['version_id'],
                 remote_key=self.data_key,
                 bucket_name=self.bucket_name,
-                s3_client=self.client,
+                backend=self.backend,
                 out_file=data_download_location
             )
 

--- a/django-caretaker/caretaker/tests/commands/test_pull_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_pull_backup_s3.py
@@ -42,14 +42,14 @@ class TestPullBackup(TestCase):
             self.assertTrue(result == StoreOutcome.STORED)
 
             # list the results to get a versionId
-            result = self.list_command._list_backups(
+            result = self.list_command.list_backups(
                 remote_key=self.json_key, bucket_name=self.bucket_name,
                 backend=self.backend
             )
 
             download_location = temporary_directory_name / self.json_key
 
-            result = self.pull_command._pull_backup(
+            result = self.pull_command.pull_backup(
                 backup_version=result[0]['version_id'],
                 remote_key=self.json_key,
                 bucket_name=self.bucket_name,
@@ -76,7 +76,7 @@ class TestPullBackup(TestCase):
             self.assertTrue(zip_file.exists())
 
             # upload the file
-            self.command._push_backup(
+            self.command.push_backup(
                 backup_local_file=zip_file, remote_key=self.data_key,
                 backend=self.backend, bucket_name=self.bucket_name)
 
@@ -85,7 +85,7 @@ class TestPullBackup(TestCase):
             self.assertFalse(zip_file.exists())
 
             # list the results to get a versionId
-            result = self.list_command._list_backups(
+            result = self.list_command.list_backups(
                 remote_key=self.data_key, bucket_name=self.bucket_name,
                 backend=self.backend
             )
@@ -93,7 +93,7 @@ class TestPullBackup(TestCase):
             data_download_location = temporary_directory_name / self.json_key
 
             # pull it back down
-            self.pull_command._pull_backup(
+            self.pull_command.pull_backup(
                 backup_version=result[0]['version_id'],
                 remote_key=self.data_key,
                 bucket_name=self.bucket_name,

--- a/django-caretaker/caretaker/tests/commands/test_push_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_push_backup_s3.py
@@ -42,7 +42,7 @@ class TestPushBackup(TestCase):
             with temporary_file.open('w') as out_file:
                 out_file.write('test2')
 
-            result = self.command._push_backup(
+            result = self.command.push_backup(
                 backup_local_file=temporary_file, remote_key=self.json_key,
                 backend=self.backend, bucket_name=self.bucket_name)
 

--- a/django-caretaker/caretaker/tests/commands/test_push_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_push_backup_s3.py
@@ -3,13 +3,14 @@ import tempfile
 from django.test import TestCase
 from moto import mock_s3
 
-from caretaker.tests.utils import setup_bucket, upload_temporary_file
+from caretaker.backend.abstract_backend import StoreOutcome
+from caretaker.tests.utils import setup_test_class_s3, upload_temporary_file
 
 
 @mock_s3
 class TestPushBackup(TestCase):
     def setUp(self):
-        setup_bucket(self)
+        setup_test_class_s3(self)
         self.logger.info('Setup for push_backup')
 
     def tearDown(self):
@@ -27,7 +28,7 @@ class TestPushBackup(TestCase):
                 temporary_directory_name=temporary_directory_name,
                 contents=self.test_contents)
 
-            self.assertTrue(result == self.command.returns[1])
+            self.assertTrue(result == StoreOutcome.STORED)
 
             # run a second time and should not store the result
             result, temporary_file = upload_temporary_file(
@@ -35,7 +36,7 @@ class TestPushBackup(TestCase):
                 temporary_directory_name=temporary_directory_name,
                 contents=self.test_contents)
 
-            self.assertTrue(result == self.command.returns[2])
+            self.assertTrue(result == StoreOutcome.IDENTICAL)
 
             # now test that when we add a new file it versions it
             with temporary_file.open('w') as out_file:
@@ -43,6 +44,6 @@ class TestPushBackup(TestCase):
 
             result = self.command._push_backup(
                 backup_local_file=temporary_file, remote_key=self.json_key,
-                s3_client=self.client, bucket_name=self.bucket_name)
+                backend=self.backend, bucket_name=self.bucket_name)
 
-            self.assertTrue(result == self.command.returns[1])
+            self.assertTrue(result == StoreOutcome.STORED)

--- a/django-caretaker/caretaker/tests/commands/test_run_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_run_backup_s3.py
@@ -47,7 +47,7 @@ class TestRunBackup(TestCase):
             self.assertTrue(result == StoreOutcome.STORED)
 
             # create a backup record including this directory
-            self.run_command._run_backup(
+            self.run_command.run_backup(
                 output_directory=temporary_directory_name,
                 path_list=[temporary_directory_name],
                 bucket_name=self.bucket_name,
@@ -56,7 +56,7 @@ class TestRunBackup(TestCase):
 
             # now check that the files exist in S3
             # list the results to get a versionId of the SQL backup
-            result = self.list_command._list_backups(
+            result = self.list_command.list_backups(
                 remote_key=self.dump_key, bucket_name=self.bucket_name,
                 backend=self.backend
             )
@@ -65,7 +65,7 @@ class TestRunBackup(TestCase):
                 missing_ok=True)
             download_location = temporary_directory_name / self.json_key
 
-            result = self.pull_command._pull_backup(
+            result = self.pull_command.pull_backup(
                 backup_version=result[0]['version_id'],
                 remote_key=self.dump_key,
                 bucket_name=self.bucket_name,
@@ -82,7 +82,7 @@ class TestRunBackup(TestCase):
                     self.fail('The stored object could not be JSON decoded')
 
             # now check the archive zip
-            result = self.list_command._list_backups(
+            result = self.list_command.list_backups(
                 remote_key=self.data_key, bucket_name=self.bucket_name,
                 backend=self.backend
             )
@@ -91,7 +91,7 @@ class TestRunBackup(TestCase):
                 missing_ok=True)
             download_location = temporary_directory_name / self.data_key
 
-            result = self.pull_command._pull_backup(
+            result = self.pull_command.pull_backup(
                 backup_version=result[0]['version_id'],
                 remote_key=self.data_key,
                 bucket_name=self.bucket_name,

--- a/django-caretaker/caretaker/tests/commands/test_run_backup_s3.py
+++ b/django-caretaker/caretaker/tests/commands/test_run_backup_s3.py
@@ -6,7 +6,7 @@ import django
 from django.test import TestCase
 from moto import mock_s3
 
-from caretaker.backend.abstract_backend import BackendFactory, StoreOutcome
+from caretaker.backend.abstract_backend import StoreOutcome
 from caretaker.management.commands.list_backups import Command as ListCommand
 from caretaker.management.commands.pull_backup import Command as PullCommand
 from caretaker.management.commands.run_backup import Command as RunCommand
@@ -69,7 +69,7 @@ class TestRunBackup(TestCase):
                 backup_version=result[0]['version_id'],
                 remote_key=self.dump_key,
                 bucket_name=self.bucket_name,
-                s3_client=self.client,
+                backend=self.backend,
                 out_file=download_location
             )
 
@@ -95,7 +95,7 @@ class TestRunBackup(TestCase):
                 backup_version=result[0]['version_id'],
                 remote_key=self.data_key,
                 bucket_name=self.bucket_name,
-                s3_client=self.client,
+                backend=self.backend,
                 out_file=download_location
             )
 

--- a/django-caretaker/caretaker/tests/settings.py
+++ b/django-caretaker/caretaker/tests/settings.py
@@ -132,4 +132,4 @@ AWS_DEFAULT_REGION = 'eu-west-2'
 
 CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
 CARETAKER_BACKEND = 'Amazon S3'
-
+CARETAKER_BACKENDS = ['caretaker.backend.backends.s3']

--- a/django-caretaker/caretaker/tests/settings.py
+++ b/django-caretaker/caretaker/tests/settings.py
@@ -129,5 +129,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 AWS_ACCESS_KEY_ID = 'DEFAULT'
 AWS_SECRET_ACCESS_KEY = 'DEFAULT'
 AWS_DEFAULT_REGION = 'eu-west-2'
-BACKUP_BUCKET = 'caretakertestbackup'
+
+CARETAKER_BACKUP_BUCKET = 'caretakertestbackup'
+CARETAKER_BACKEND = 'Amazon S3'
 

--- a/django-caretaker/caretaker/tests/utils.py
+++ b/django-caretaker/caretaker/tests/utils.py
@@ -4,13 +4,14 @@ from pathlib import Path
 
 import boto3
 
+from caretaker.backend.abstract_backend import BackendFactory
 from caretaker.main_utils import log
 from caretaker.management.commands.push_backup import Command as PushCommand
 
 DEV_NULL = open(os.devnull, "w")
 
 
-def setup_bucket(test_class):
+def setup_test_class_s3(test_class):
     """
     Generic class to set up tests that require push functionality
     :param test_class: the class to mutate
@@ -41,6 +42,8 @@ def setup_bucket(test_class):
         }
     )
 
+    test_class.backend = BackendFactory.get_backend('Amazon S3')
+
     return test_class
 
 
@@ -53,7 +56,7 @@ def upload_temporary_file(test_class, temporary_directory_name, contents):
     # run the first time to store the result
     result = test_class.command._push_backup(
         backup_local_file=temporary_file, remote_key=test_class.json_key,
-        s3_client=test_class.client, bucket_name=test_class.bucket_name)
+        backend=test_class.backend, bucket_name=test_class.bucket_name)
 
     return result, temporary_file
 

--- a/django-caretaker/caretaker/tests/utils.py
+++ b/django-caretaker/caretaker/tests/utils.py
@@ -54,7 +54,7 @@ def upload_temporary_file(test_class, temporary_directory_name, contents):
         out_file.write(contents)
 
     # run the first time to store the result
-    result = test_class.command._push_backup(
+    result = test_class.command.push_backup(
         backup_local_file=temporary_file, remote_key=test_class.json_key,
         backend=test_class.backend, bucket_name=test_class.bucket_name)
 

--- a/django-caretaker/setup.cfg
+++ b/django-caretaker/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-caretaker
-version = 0.2.0
+version = 0.3.0
 description = A Django app for backups using S3 storage.
 url = https://github.com/MartinPaulEve/django-caretaker
 author = Martin Paul Eve


### PR DESCRIPTION
This pull request enables the abstraction of backend providers so that we can support multiple cloud services. It defines a common interface for backend providers and an abstract factory that can produce the required objects.

This PR adds the following settings:

```
CARETAKER_BACKEND = 'Amazon S3'
CARETAKER_BACKENDS = ['caretaker.backend.backends.s3']
```

The CARETAKER_BACKENDS setting defines available backend providers while the CARETAKER_BACKEND specifies, by name, the provider to use.

At present, the only provider is Amazon S3, but this will grow over time.

This PR closes #5 and contributes to #6 