### PR TITLE
Adds autodoc (with docker support)

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,7 @@
+FROM sphinxdoc/sphinx
+
+
+WORKDIR /docs
+ADD requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,5 +15,16 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+
+# To run with docker, first build the image with `make build-docker-image`
+# then you can run `make docker` to generate the autodocs and regular documentation
+# if you only want the autodoc in RST format run `make docker-autodoc`
+build-docker-image:
+	@docker build -f Dockerfile ${PWD}../../ -t django-caretaker/sphinx-rtd
+docker-autodoc:
+	@docker run  --rm -ti -v ${PWD}:/docs  -v ${PWD}/../django-caretaker:/vol/django-caretaker -e CARETAKER_PATH=/vol/django-caretaker sphinxdoc/sphinx sphinx-apidoc -o "." /vol/django-caretaker/caretaker
 docker:
-	@docker run --rm -ti -v ${PWD}:/docs sphinxdoc/sphinx
+	@bash -c "make docker-autodoc"
+	@docker run  --rm -ti -v ${PWD}:/docs  -v ${PWD}/../django-caretaker:/vol/django-caretaker -e CARETAKER_PATH=/vol/django-caretaker django-caretaker/sphinx-rtd
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,8 +1,5 @@
 # Minimal makefile for Sphinx documentation
 #
-
-# You can set these variables from the command line, and also
-# from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
@@ -18,3 +15,5 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+docker:
+	@docker run --rm -ti -v ${PWD}:/docs sphinxdoc/sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+import os
+import sys
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -10,6 +12,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+PATH = os.environ.get(
+    "CARETAKER_PATH",
+    os.path.abspath("../django-caretaker/")
+)
+sys.path.insert(0, PATH)
 #import os
 #import sys
 #sys.path.insert(0, os.path.abspath('./django-caretaker/caretaker'))
@@ -27,8 +34,7 @@ author = 'Martin Paul Eve'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = ["sphinx.ext.autodoc"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
- Adds a few targets for building the docs within a Docker environment
- Adds support for building the rST for caretaker with `sphinx.autodoc`