### PR TITLE
Add support for post-create-backup execution hooks.

### DIFF
--- a/README.template
+++ b/README.template
@@ -198,6 +198,16 @@ SQL export is not available for Oracle. It's a nightmare to get Oracle tools ins
 ## SQLite support
 We do not support in-memory SQLite databases for import_file operations. It's not possible to destroy and reload the in-memory database through Django, which is what we do with the on-disk equivalent.
 
+## Post-Execution Hooks
+Frontends support post-execution hooks. You can use these to execute commands on the local system after a backup has been created.
+
+To use post-execution hooks, add items to the CARETAKER_POST_EXECUTE variable:
+
+    CARETAKER_POST_EXECUTE = ['rsync -avz --delete {{ local_store_directory }}/{{ backup_bucket }} remote:~/backups',
+                          'ls {{ local_store_directory }}/{{ backup_bucket }}']
+
+In post-execution hooks you can get access to CARETAKER_ variables by using the ""{{ variable_name }}"" syntax shown above. Hence, "{{ local_store_directory}}" in a hook will be converted to the value of CARETAKER.LOCAL_STORE_DIRECTORY. Do not include the word "CTVARIABLE" in a post-execute hook.
+
 ## Credits
 * [A context manager for files or stdout](https://stackoverflow.com/a/17603000/349003) by Wolph.
 * [AWS CLI](https://aws.amazon.com/cli/) for interactions with AWS.

--- a/django-caretaker/caretaker/settings.py
+++ b/django-caretaker/caretaker/settings.py
@@ -200,3 +200,5 @@ CARETAKER_FRONTEND = 'Django'  # note that this is case sensitive
 CARETAKER_FRONTENDS = ['caretaker.frontend.frontends.django']
 CARETAKER_LOCAL_STORE_DIRECTORY = '/home/martin/caretaker_backups'
 CARETAKER_LOCAL_FILE_PATTERN = '{{version}}.{{date}}'
+CARETAKER_POST_EXECUTE = ['rsync -avz --delete {{ local_store_directory}}/{{ backup_bucket}} remote:~/backups',
+                          'ls {{ local_store_directory}}/{{ backup_bucket}}']

--- a/django-caretaker/caretaker/tests/frontend/django/backend/local/caretaker_test.py
+++ b/django-caretaker/caretaker/tests/frontend/django/backend/local/caretaker_test.py
@@ -32,6 +32,8 @@ class AbstractDjangoLocalTest(AbstractCaretakerTest, metaclass=abc.ABCMeta):
         settings.CARETAKER_BACKUP_BUCKET = 'caretaker_bucket'
         settings.CARETAKER_LOCAL_STORE_DIRECTORY = ''
         settings.CARETAKER_LOCAL_FILE_PATTERN = '{{version}}.{{date}}'
+        settings.CARETAKER_POST_EXECUTE = [
+            'echo {{ local_store_directory}}/{{ backup_bucket}}']
 
         self.bucket_name = settings.CARETAKER_BACKUP_BUCKET
 

--- a/django-caretaker/caretaker/tests/frontend/django/backend/s3/caretaker_test.py
+++ b/django-caretaker/caretaker/tests/frontend/django/backend/s3/caretaker_test.py
@@ -30,6 +30,11 @@ class AbstractDjangoS3Test(AbstractCaretakerTest, metaclass=abc.ABCMeta):
         settings.CARETAKER_BACKEND = ''
         settings.CARETAKER_FRONTEND = ''
         settings.CARETAKER_BACKUP_BUCKET = 'caretaker_bucket'
+        settings.CARETAKER_LOCAL_STORE_DIRECTORY = '/home/martin'
+        settings.CARETAKER_POST_EXECUTE = [
+            'echo hello {{ local_store_directory}}/{{ backup_bucket}}',
+            'echo just_hello'
+        ]
 
         self.bucket_name = settings.CARETAKER_BACKUP_BUCKET
 

--- a/django-caretaker/caretaker/tests/settings.py
+++ b/django-caretaker/caretaker/tests/settings.py
@@ -199,3 +199,4 @@ CARETAKER_FRONTEND = 'Django'
 CARETAKER_FRONTENDS = ['caretaker.frontend.frontends.django']
 CARETAKER_LOCAL_STORE_DIRECTORY = '/home/martin/caretaker_backups'
 CARETAKER_LOCAL_FILE_PATTERN = '{{version}}.{{date}}'
+CARETAKER_POST_EXECUTE = ['rsync -avz --delete {{ local_store_directory}}/{{ backup_bucket}} remote:~/backups', 'ls {{ local_store_directory}}/{{ backup_bucket}}']


### PR DESCRIPTION
This solves the demand for rsync backend in #45 because users can add rsync commands to CARETAKER_POST_EXECUTE. Closes #45 